### PR TITLE
set "use-github-api" to "false"

### DIFF
--- a/src/PHP/ComposerInit.php
+++ b/src/PHP/ComposerInit.php
@@ -17,7 +17,8 @@ final readonly class ComposerInit implements Dockerfile\LayerInterface, \Stringa
         return (string) new Dockerfile\Run(sprintf(
             <<<'RUN'
                 set -ex \
-                    && composer init --no-interaction --name=%s && pwd
+                    && composer init --no-interaction --name=%s \
+                    && composer config use-github-api false
                 RUN,
             $this->name
         ));


### PR DESCRIPTION
… to avoid hitting the API limit when building 3 satellites in a row, because docker images don't have a token

<img width="1011" alt="image" src="https://github.com/php-etl/dockerfile/assets/28787740/12809ab4-cbe3-4cf7-873a-947a022ad105">

---

<img width="1045" alt="image" src="https://github.com/php-etl/dockerfile/assets/28787740/f72113e2-a03d-47c3-afdc-7c1c258e3a54">
